### PR TITLE
feat: support china regions

### DIFF
--- a/API.md
+++ b/API.md
@@ -38,6 +38,7 @@ new Cluster(scope: Construct, id: string, props?: ClusterProps)
   * **capacitySize** (<code>number</code>)  number of instances. __*Default*__: 1
   * **defaultInstanceType** (<code>[InstanceType](#aws-cdk-aws-ec2-instancetype)</code>)  The default EC2 instance type. __*Default*__: t3.large
   * **machineImage** (<code>[IMachineImage](#aws-cdk-aws-ec2-imachineimage)</code>)  AMI for the EKS-D instance node. __*Default*__: The latest AMI from ubuntu-focal-20.04-amd64-server
+  * **outputAmiId** (<code>boolean</code>)  Print AMI ID in the output. __*Default*__: true
   * **vpc** (<code>[IVpc](#aws-cdk-aws-ec2-ivpc)</code>)  VPC for the cluster. __*Default*__: get or create a VPC
 
 
@@ -54,9 +55,10 @@ The AMI provider to get the latest Ubuntu Linux AMI.
 
 
 ```ts
-new UbumtuAmiProvider(userData: UserData)
+new UbumtuAmiProvider(scope: Construct, userData: UserData)
 ```
 
+* **scope** (<code>[Construct](#aws-cdk-core-construct)</code>)  *No description*
 * **userData** (<code>[UserData](#aws-cdk-aws-ec2-userdata)</code>)  *No description*
 
 
@@ -67,6 +69,7 @@ new UbumtuAmiProvider(userData: UserData)
 Name | Type | Description 
 -----|------|-------------
 **amiId** | <code>[IMachineImage](#aws-cdk-aws-ec2-imachineimage)</code> | <span></span>
+**scope** | <code>[Construct](#aws-cdk-core-construct)</code> | <span></span>
 **userData** | <code>[UserData](#aws-cdk-aws-ec2-userdata)</code> | <span></span>
 
 
@@ -83,6 +86,7 @@ Name | Type | Description
 **capacitySize**? | <code>number</code> | number of instances.<br/>__*Default*__: 1
 **defaultInstanceType**? | <code>[InstanceType](#aws-cdk-aws-ec2-instancetype)</code> | The default EC2 instance type.<br/>__*Default*__: t3.large
 **machineImage**? | <code>[IMachineImage](#aws-cdk-aws-ec2-imachineimage)</code> | AMI for the EKS-D instance node.<br/>__*Default*__: The latest AMI from ubuntu-focal-20.04-amd64-server
+**outputAmiId**? | <code>boolean</code> | Print AMI ID in the output.<br/>__*Default*__: true
 **vpc**? | <code>[IVpc](#aws-cdk-aws-ec2-ivpc)</code> | VPC for the cluster.<br/>__*Default*__: get or create a VPC
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,13 @@ export interface ClusterProps {
    * @default - The latest AMI from ubuntu-focal-20.04-amd64-server
    */
   readonly machineImage?: ec2.IMachineImage;
+
+  /**
+   * Print AMI ID in the output
+   * 
+   * @default - true
+   */
+  readonly outputAmiId?: boolean;
 }
 
 /**
@@ -50,11 +57,15 @@ export class Cluster extends cdk.Construct {
     );
     const asg = new autoscaling.AutoScalingGroup(this, 'ASG', {
       instanceType: props.defaultInstanceType ?? this.defaultInstanceType,
-      machineImage: props.machineImage ?? new UbumtuAmiProvider(userData).amiId,
+      machineImage: props.machineImage ?? new UbumtuAmiProvider(this, userData).amiId,
       minCapacity: props.capacitySize ?? this.defaultCapacitySize,
       vpc,
     });
     asg.role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
+
+    if(props.outputAmiId !== false) {
+      new cdk.CfnOutput(this, 'AmiId', { value: new UbumtuAmiProvider(this, userData).amiId.getImage(this).imageId })
+    }
   }
 }
 
@@ -71,16 +82,26 @@ function getOrCreateVpc(scope: cdk.Construct): ec2.IVpc {
  * The AMI provider to get the latest Ubuntu Linux AMI
  */
 export class UbumtuAmiProvider {
-  constructor(readonly userData: ec2.UserData) {}
+  constructor(readonly scope: cdk.Construct, readonly userData: ec2.UserData) {}
   public get amiId() {
+    const stack = cdk.Stack.of(this.scope)
+    const filterName = isChina(stack) ? 'ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????'
+      : 'ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????'
+    const owners = isChina(stack) ? '837727238323' : '099720109477'
     return ec2.MachineImage.lookup({
       name: 'Ubuntu',
       filters: {
-        name: ['ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????'],
+        name: [filterName],
         state: ['available'],
       },
-      owners: ['099720109477'],
+      owners: [owners],
       userData: this.userData,
     });
   }
 }
+
+function isChina(stack: cdk.Stack) {
+  return !cdk.Token.isUnresolved(stack.region) && stack.region.startsWith('cn-')
+}
+
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export interface ClusterProps {
 
   /**
    * Print AMI ID in the output
-   * 
+   *
    * @default - true
    */
   readonly outputAmiId?: boolean;
@@ -63,8 +63,8 @@ export class Cluster extends cdk.Construct {
     });
     asg.role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
 
-    if(props.outputAmiId !== false) {
-      new cdk.CfnOutput(this, 'AmiId', { value: new UbumtuAmiProvider(this, userData).amiId.getImage(this).imageId })
+    if (props.outputAmiId !== false) {
+      new cdk.CfnOutput(this, 'AmiId', { value: new UbumtuAmiProvider(this, userData).amiId.getImage(this).imageId });
     }
   }
 }
@@ -84,10 +84,10 @@ function getOrCreateVpc(scope: cdk.Construct): ec2.IVpc {
 export class UbumtuAmiProvider {
   constructor(readonly scope: cdk.Construct, readonly userData: ec2.UserData) {}
   public get amiId() {
-    const stack = cdk.Stack.of(this.scope)
+    const stack = cdk.Stack.of(this.scope);
     const filterName = isChina(stack) ? 'ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????'
-      : 'ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????'
-    const owners = isChina(stack) ? '837727238323' : '099720109477'
+      : 'ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????';
+    const owners = isChina(stack) ? '837727238323' : '099720109477';
     return ec2.MachineImage.lookup({
       name: 'Ubuntu',
       filters: {
@@ -101,7 +101,7 @@ export class UbumtuAmiProvider {
 }
 
 function isChina(stack: cdk.Stack) {
-  return !cdk.Token.isUnresolved(stack.region) && stack.region.startsWith('cn-')
+  return !cdk.Token.isUnresolved(stack.region) && stack.region.startsWith('cn-');
 }
 
 

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -2,6 +2,11 @@
 
 exports[`integ snapshot validation 1`] = `
 Object {
+  "Outputs": Object {
+    "ClusterAmiId375DE810": Object {
+      "Value": "ami-1234",
+    },
+  },
   "Resources": Object {
     "ClusterASG2DD591B2": Object {
       "Properties": Object {


### PR DESCRIPTION
- support auto-select latest Ubuntu AMI from China regions including `cn-north-1` and `cn-northwest-1`